### PR TITLE
Fix non-aligned data handling

### DIFF
--- a/zbar/image.h
+++ b/zbar/image.h
@@ -160,11 +160,11 @@ static inline zbar_image_t *_zbar_image_copy(const zbar_image_t *src,
 	char *spc, *dpc;
 
 	/* Do it word per word, in order to speedup */
-	for (i = 0; i < len; i += sizeof(long))
+	for (i = 0; i < len - (len % sizeof(long)); i += sizeof(long))
 	    *dp++ = ~(*sp++);
 
 	/* Deal with non-aligned remains, if any */
-	len -= i;
+	len = len % sizeof(long);
 	spc = (char *)sp;
 	dpc = (char *)dp;
 	for (i = 0; i < len; i++)


### PR DESCRIPTION
Update _zbar_image_copy method to handle non-aligned data correctly.